### PR TITLE
feat(nest-iap): use configurable module builder to have forRoot{,Async} methods

### DIFF
--- a/packages/nest-iap/src/iap.module-definition.ts
+++ b/packages/nest-iap/src/iap.module-definition.ts
@@ -1,0 +1,20 @@
+import { type DynamicModule, ConfigurableModuleBuilder } from '@nestjs/common';
+
+import { type IAPConfig } from './interfaces/iap-module-config.interface';
+
+/**
+ * @see {@link https://docs.nestjs.com/fundamentals/dynamic-modules#configurable-module-builder}
+ */
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE, ASYNC_OPTIONS_TYPE } =
+  new ConfigurableModuleBuilder<IAPConfig>()
+    .setExtras(
+      {
+        isGlobal: true,
+      },
+      (definition: DynamicModule, extras: { isGlobal: boolean }) => ({
+        ...definition,
+        global: extras.isGlobal,
+      }),
+    )
+    .setClassMethodName('forRoot')
+    .build();

--- a/packages/nest-iap/src/iap.module.ts
+++ b/packages/nest-iap/src/iap.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 
-import { ConfigurableModuleClass } from './iap.module-definition';
+import { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } from './iap.module-definition';
 import { IAPService } from './iap.service';
 
 @Module({
-  providers: [IAPService],
+  providers: [
+    {
+      provide: MODULE_OPTIONS_TOKEN,
+      useValue: MODULE_OPTIONS_TOKEN,
+    },
+    IAPService,
+  ],
   exports: [IAPService],
 })
 export class IAPModule extends ConfigurableModuleClass {}

--- a/packages/nest-iap/src/iap.module.ts
+++ b/packages/nest-iap/src/iap.module.ts
@@ -1,21 +1,10 @@
-import { type DynamicModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 
-import { type IAPConfig, IAP_CONFIG, IAPService } from './iap.service';
+import { ConfigurableModuleClass } from './iap.module-definition';
+import { IAPService } from './iap.service';
 
-@Module({})
-export class IAPModule {
-  static forRoot(config: IAPConfig): DynamicModule {
-    return {
-      global: true,
-      module: IAPModule,
-      providers: [
-        {
-          provide: IAP_CONFIG,
-          useValue: config,
-        },
-        IAPService,
-      ],
-      exports: [IAPService],
-    };
-  }
-}
+@Module({
+  providers: [IAPService],
+  exports: [IAPService],
+})
+export class IAPModule extends ConfigurableModuleClass {}

--- a/packages/nest-iap/src/iap.service.ts
+++ b/packages/nest-iap/src/iap.service.ts
@@ -1,27 +1,23 @@
 import {
-  type AppleConfig,
   type AppleRequestBody,
-  type GoogleConfig,
+  type AppleVerifyResponse,
   type GoogleRequestBody,
+  type GoogleVerifyResponse,
   verifyAppleReceipt,
   verifyGoogleReceipt,
 } from '@jeremybarbet/node-iap';
 import { Inject, Injectable } from '@nestjs/common';
 
-export interface IAPConfig {
-  apple?: AppleConfig;
-  google?: GoogleConfig;
-}
-
-export const IAP_CONFIG = 'IAP_CONFIG';
+import type { IAPConfig } from './interfaces/iap-module-config.interface';
+import { MODULE_OPTIONS_TOKEN } from './iap.module-definition';
 
 @Injectable()
 export class IAPService {
-  constructor(@Inject(IAP_CONFIG) private readonly config: IAPConfig) {
+  constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly config: IAPConfig) {
     this.config = config;
   }
 
-  async verifyAppleReceipt(requestBody: AppleRequestBody) {
+  async verifyAppleReceipt(requestBody: AppleRequestBody): Promise<AppleVerifyResponse> {
     if (!this.config?.apple) {
       throw new Error('Missing Apple configuration.');
     }
@@ -29,7 +25,7 @@ export class IAPService {
     return await verifyAppleReceipt(requestBody, this.config.apple);
   }
 
-  async verifyGoogleReceipt(requestBody: GoogleRequestBody) {
+  async verifyGoogleReceipt(requestBody: GoogleRequestBody): Promise<GoogleVerifyResponse> {
     if (!this.config?.google) {
       throw new Error('Missing Google configuration.');
     }

--- a/packages/nest-iap/src/interfaces/iap-module-config.interface.ts
+++ b/packages/nest-iap/src/interfaces/iap-module-config.interface.ts
@@ -1,0 +1,6 @@
+import type { AppleConfig, GoogleConfig } from '@jeremybarbet/node-iap';
+
+export interface IAPConfig {
+  apple?: AppleConfig;
+  google?: GoogleConfig;
+}


### PR DESCRIPTION
**Why this PR?**

I wanted to use this library in a production grade setting with `ConfigService` and `Joi` for config validation.
With the `forRoot` method of the existing solution, I have no chance to pass the `config` from my `ConfigService` to the `IAPModule.forRoot(... here be values from config service...)`.

The configurable module builder creates the `forRoot` and `forRootAsync` methods for us and we have to do less tedious work ourselves in the same go.